### PR TITLE
Add output reco collection with nSLD parameters

### DIFF
--- a/source/include/MySLDecayFinder.h
+++ b/source/include/MySLDecayFinder.h
@@ -2,6 +2,7 @@
 #define MySLDecayFinder_h 1
 
 #include "EVENT/LCStrVec.h"
+#include "IMPL/LCCollectionVec.h"
 #include "marlin/Processor.h"
 #include "lcio.h"
 #include <string>
@@ -87,6 +88,8 @@ private:
   int				m_nEvtSum{};
 
   std::string			m_mcParticleCollection{};
+  std::string		    m_outcolSLDecays{};
+  LCCollectionVec*      m_col_SLDecays{};
 
   int				m_printing;
   std::string         m_rootFile{};                           ///<

--- a/source/src/MySLDecayFinder.cc
+++ b/source/src/MySLDecayFinder.cc
@@ -26,7 +26,7 @@ MySLDecayFinder aMySLDecayFinder ;
 
 
 MySLDecayFinder::MySLDecayFinder() :
-	Processor("MySLDecayFinder"),
+	Processor("SLDecayFinder"),
 	m_nRun(0),
      m_nEvt(0),
      m_nRunSum(0),
@@ -90,6 +90,12 @@ MySLDecayFinder::MySLDecayFinder() :
 						std::string("MySLDecayFinder.root")
 						);
 
+    registerOutputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                       "SemileptonicDecays", // Currently undefined and only used to carry parameters of number of decays
+                       "To be defined",
+                       m_outcolSLDecays ,
+                       std::string("SLDecays")
+                       );
 }
 
 
@@ -140,11 +146,19 @@ void MySLDecayFinder::processEvent( LCEvent *pLCEvent )
 	if ((m_nEvtSum % 100) == 0)
          std::cout << " processed events: " << m_nEvtSum << std::endl;
 
+    // New reco particle collection for the semi-leptonic decays
+    m_col_SLDecays = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
 
 	this->Clear();
 	this->ExtractCollections(pLCEvent);
 	this->FindSLDecays(pLCEvent);
 	m_pTTree->Fill();
+
+
+    // Set numbers of semileptonic decays as event parameters
+    m_col_SLDecays->parameters().setValue("nBSLD", (int)m_nSLDecayBHad);
+    m_col_SLDecays->parameters().setValue("nCSLD", (int)m_nSLDecayCHad);
+    pLCEvent->addCollection(m_col_SLDecays, m_outcolSLDecays);
 }
 
 
@@ -234,6 +248,7 @@ void MySLDecayFinder::ExtractCollections(EVENT::LCEvent *pLCEvent)
 
 void MySLDecayFinder::FindSLDecays(EVENT::LCEvent *pLCEvent)
 {
+
 	try
 	{
 		const EVENT::LCCollection *pLCCollection = pLCEvent->getCollection(m_mcParticleCollection);
@@ -291,4 +306,5 @@ void MySLDecayFinder::FindSLDecays(EVENT::LCEvent *pLCEvent)
      {
          streamlog_out(WARNING) << "Could not extract Semi-Leptonic decay " << std::endl;
      }
+
 }


### PR DESCRIPTION
- Add ReconstructedParticle output collection (currently empty) for the semi-leptonic decays.
- Add parameters to output collection that write number of semi-leptonic C and B hadron decays.